### PR TITLE
Bruker ny versjon av crawler

### DIFF
--- a/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/CrawlerClient.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/CrawlerClient.kt
@@ -57,7 +57,8 @@ class CrawlerClient(val crawlerProperties: CrawlerProperties, val restTemplate: 
   fun getStatus(crawlResultat: CrawlResultat): Result<CrawlStatus> =
       when (crawlResultat) {
         is CrawlResultat.IkkeFerdig -> {
-          data class StatusDTO(val runtimeStatus: String, val output: List<String>?)
+          data class CrawlerOutput(val url: String, val title: String)
+          data class StatusDTO(val runtimeStatus: String, val output: List<CrawlerOutput>?)
 
           runCatching {
             val response =
@@ -67,7 +68,7 @@ class CrawlerClient(val crawlerProperties: CrawlerProperties, val restTemplate: 
               "Running" -> CrawlStatus.Running
               "Completed" -> {
                 val nettsider =
-                    response.output?.map { URL(it) }
+                    response.output?.map { crawlerOutput -> URL(crawlerOutput.url) }
                         ?: throw RuntimeException("`output` fra crawler er `null`")
                 CrawlStatus.Completed(nettsider)
               }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,6 @@ spring.flyway.schemas=testlab2_testing
 server.error.include-stacktrace=never
 autotester.url=https://funcddttestlabautotester.azurewebsites.net/api/orchestrators/orchestrator
 autotester.code=
-crawler.url=https://funcDDTTestlabCrawler.azurewebsites.net/api/orchestrators/crawlerOrchestrator
+crawler.url=https://funcDDTTestlabCrawler-test.azurewebsites.net/api/orchestrators/crawlerOrchestrator
 crawler.code=
 features.startTesting=false


### PR DESCRIPTION
Ny versjon av crawleren har et litt annet outputformat, som inkluderer tittel i tillegg til url. Endrer CrawlerClient til å virke med dette nye formatet.

DFK-210