### PR TITLE
tilpasninger til ny crawler

### DIFF
--- a/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/CrawlResultat.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/CrawlResultat.kt
@@ -39,7 +39,7 @@ fun updateStatus(crawlResultat: CrawlResultat, newStatus: CrawlStatus): CrawlRes
         when (newStatus) {
           is CrawlStatus.Completed ->
               CrawlResultat.Ferdig(
-                  newStatus.nettsider,
+                  newStatus.output.map { crawlerOutput -> URL(crawlerOutput.url) },
                   crawlResultat.statusUrl,
                   crawlResultat.loeysing,
                   Instant.now())

--- a/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/MaalingResource.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/MaalingResource.kt
@@ -205,6 +205,7 @@ class MaalingResource(
           runCatching {
             val oppdaterteResultater =
                 maaling.crawlResultat
+                    .filterIsInstance<CrawlResultat.IkkeFerdig>()
                     .map {
                       crawlerClient.getStatus(it).map { newStatus -> updateStatus(it, newStatus) }
                     }

--- a/src/test/kotlin/no/uutilsynet/testlab2testing/maaling/CrawlResultatKtTest.kt
+++ b/src/test/kotlin/no/uutilsynet/testlab2testing/maaling/CrawlResultatKtTest.kt
@@ -16,11 +16,14 @@ class CrawlResultatKtTest {
   fun toFerdig() {
     val ikkeFerdig =
         CrawlResultat.IkkeFerdig(URL("https://status.uri"), uutilsynetLoeysing, Instant.now())
-    val nettsider =
+    val crawlerOutput =
         listOf(
-            URL("https://www.uutilsynet.no/"),
-            URL("https://www.uutilsynet.no/veiledning/tilgjengelighetserklaering/1127"))
-    val updated = updateStatus(ikkeFerdig, CrawlStatus.Completed(nettsider)) as CrawlResultat.Ferdig
-    assertThat(updated.nettsider).containsExactlyElementsOf(nettsider)
+            CrawlerOutput("https://www.uutilsynet.no/", "uutilsynet"),
+            CrawlerOutput(
+                "https://www.uutilsynet.no/veiledning/tilgjengelighetserklaering/1127",
+                "uutilsynet"))
+    val updated =
+        updateStatus(ikkeFerdig, CrawlStatus.Completed(crawlerOutput)) as CrawlResultat.Ferdig
+    assertThat(updated.nettsider).containsExactlyElementsOf(crawlerOutput.map { URL(it.url) })
   }
 }


### PR DESCRIPTION
Oppdaget en feil som oppsto når crawleren returnerte med en feilmelding, nemlig at vi ikke støttet at `output` var en string. Endrer CrawlStatus til å støtte dette tilfellet.

DFK-210