### PR TITLE
forenkler data for målingliste

### DIFF
--- a/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/Maaling.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/Maaling.kt
@@ -89,6 +89,9 @@ sealed class Maaling {
   }
 }
 
+// Enkel representasjon av måling som brukes i utlisting av alle målinger.
+data class MaalingListElement(val id: Int, val navn: String, val status: String)
+
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "id")
 @JsonSubTypes(
     JsonSubTypes.Type(value = Aksjon.StartCrawling::class, name = "start_crawling"),

--- a/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/MaalingDAO.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/MaalingDAO.kt
@@ -152,10 +152,10 @@ class MaalingDAO(val jdbcTemplate: NamedParameterJdbcTemplate) {
   @Transactional
   fun deleteMaaling(id: Int): Int = jdbcTemplate.update(deleteMaalingSql, mapOf("id" to id))
 
-  fun getMaalingList(): List<Maaling> =
+  fun getMaalingList(): List<MaalingListElement> =
       jdbcTemplate
           .query(selectMaalingSql, maalingRowmapper)
-          .map { it.toMaaling() }
+          .map { MaalingListElement(it.id, it.navn, it.status.status) }
           .also { logger.debug("hentet ${it.size} målinger fra databasen") }
 
   private fun MaalingDTO.toMaaling(): Maaling {

--- a/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/MaalingResource.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/MaalingResource.kt
@@ -58,7 +58,7 @@ class MaalingResource(
           .getOrElse { exception -> handleErrors(exception) }
 
   @GetMapping
-  fun list(): List<Maaling> {
+  fun list(): List<MaalingListElement> {
     return maalingDAO.getMaalingList()
   }
 

--- a/src/test/kotlin/no/uutilsynet/testlab2testing/maaling/MaalingIntegrationTests.kt
+++ b/src/test/kotlin/no/uutilsynet/testlab2testing/maaling/MaalingIntegrationTests.kt
@@ -71,15 +71,14 @@ class MaalingIntegrationTests(
     @DisplayName("så skal vi kunne finne den i lista over alle målinger")
     fun listMaalinger() {
       val (id) = restTemplate.getForObject(location, MaalingDTO::class.java)
-      val maalingList = object : ParameterizedTypeReference<List<MaalingDTO>>() {}
+      val maalingList = object : ParameterizedTypeReference<List<MaalingListElement>>() {}
 
-      val maalinger: ResponseEntity<List<MaalingDTO>> =
+      val maalinger: ResponseEntity<List<MaalingListElement>> =
           restTemplate.exchange("/v1/maalinger", HttpMethod.GET, HttpEntity.EMPTY, maalingList)!!
       val thisMaaling = maalinger.body?.find { it.id == id }!!
 
       assertThat(thisMaaling.id, equalTo(id))
       assertThat(thisMaaling.navn, equalTo(maalingTestName))
-      assertThat(thisMaaling.loeysingList, equalTo(loeysingList))
     }
 
     @Test


### PR DESCRIPTION
Lager en enklere datamodell for GET /maalinger, så vi ikke returnerer så mye unødvendig data.

DFK-227