### PR TITLE
hente testresultat for måling og løysing

### DIFF
--- a/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/Maaling.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/Maaling.kt
@@ -86,6 +86,18 @@ sealed class Maaling {
     fun toTesting(maaling: Kvalitetssikring, testKoeyringar: List<TestKoeyring>): Testing {
       return Testing(maaling.id, maaling.navn, testKoeyringar)
     }
+
+    fun findFerdigeTestKoeyringar(
+        maaling: Maaling,
+        loeysingId: Int? = null
+    ): List<TestKoeyring.Ferdig> =
+        if (maaling is TestingFerdig) {
+          maaling.testKoeyringar.filterIsInstance<TestKoeyring.Ferdig>().filter {
+            loeysingId == null || it.crawlResultat.loeysing.id == loeysingId
+          }
+        } else {
+          emptyList()
+        }
   }
 }
 

--- a/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/MaalingDAO.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/MaalingDAO.kt
@@ -17,8 +17,6 @@ import no.uutilsynet.testlab2testing.maaling.MaalingDAO.MaalingParams.maalingLoe
 import no.uutilsynet.testlab2testing.maaling.MaalingDAO.MaalingParams.maalingRowmapper
 import no.uutilsynet.testlab2testing.maaling.MaalingDAO.MaalingParams.selectMaalingByIdSql
 import no.uutilsynet.testlab2testing.maaling.MaalingDAO.MaalingParams.selectMaalingSql
-import no.uutilsynet.testlab2testing.maaling.MaalingDAO.MaalingParams.selectTestResultForMaalingLoeysingParams
-import no.uutilsynet.testlab2testing.maaling.MaalingDAO.MaalingParams.selectTestResultForMaalingLoeysingSql
 import no.uutilsynet.testlab2testing.maaling.MaalingDAO.MaalingParams.testResultatRowMapper
 import no.uutilsynet.testlab2testing.maaling.MaalingDAO.MaalingParams.updateMaalingParams
 import no.uutilsynet.testlab2testing.maaling.MaalingDAO.MaalingParams.updateMaalingSql
@@ -73,7 +71,7 @@ class MaalingDAO(val jdbcTemplate: NamedParameterJdbcTemplate) {
             "maxLinksPerPage" to crawlParameters.maxLinksPerPage,
             "numLinksToSelect" to crawlParameters.numLinksToSelect)
 
-    val deleteMaalingLoeysingSql = "delete from MaalingLoeysing where idMaaling = :idMaaling"
+    const val deleteMaalingLoeysingSql = "delete from MaalingLoeysing where idMaaling = :idMaaling"
 
     val createMaalingLoysingSql =
         "insert into MaalingLoeysing (idMaaling, idLoeysing) values (:idMaaling, :idLoeysing)"
@@ -109,18 +107,6 @@ class MaalingDAO(val jdbcTemplate: NamedParameterJdbcTemplate) {
         "update MaalingV1 set navn = :navn, status = :status, max_links_per_page = :maxLinksPerPage, num_links_to_select = :numLinksToSelect where id = :id"
 
     val deleteMaalingSql = "delete from MaalingV1 where id = :id"
-
-    val selectTestResultForMaalingLoeysingSql =
-        """
-          select nettside, suksesskriterium, testregel, element_utfall, element_resultat, side_nivaa, test_vart_utfoert, pointer, html_code
-            from testresultat tr
-            join testkoeyring t on tr.testkoeyring_id = t.id
-          where t.maaling_id = :maalingId and t.loeysing_id = :loeysingId
-        """
-            .trimIndent()
-
-    fun selectTestResultForMaalingLoeysingParams(maalingId: Int, loeysingId: Int) =
-        mapOf("maalingId" to maalingId, "loeysingId" to loeysingId)
   }
 
   @Transactional
@@ -142,12 +128,6 @@ class MaalingDAO(val jdbcTemplate: NamedParameterJdbcTemplate) {
 
     return maaling?.toMaaling()
   }
-
-  fun getTestresultatForMaalingLoeysing(maalingId: Int, loeysingId: Int): List<TestResultat> =
-      jdbcTemplate.query(
-          selectTestResultForMaalingLoeysingSql,
-          selectTestResultForMaalingLoeysingParams(maalingId, loeysingId),
-          testResultatRowMapper)
 
   @Transactional
   fun deleteMaaling(id: Int): Int = jdbcTemplate.update(deleteMaalingSql, mapOf("id" to id))

--- a/src/test/kotlin/no/uutilsynet/testlab2testing/maaling/MaalingIntegrationTests.kt
+++ b/src/test/kotlin/no/uutilsynet/testlab2testing/maaling/MaalingIntegrationTests.kt
@@ -28,7 +28,6 @@ class MaalingIntegrationTests(
     @Autowired val restTemplate: TestRestTemplate,
     @Autowired val maalingDAO: MaalingDAO
 ) {
-
   @AfterAll
   fun cleanup() {
     maalingDAO.jdbcTemplate.update(

--- a/src/test/kotlin/no/uutilsynet/testlab2testing/maaling/MaalingKtTest.kt
+++ b/src/test/kotlin/no/uutilsynet/testlab2testing/maaling/MaalingKtTest.kt
@@ -6,6 +6,7 @@ import no.uutilsynet.testlab2testing.maaling.CrawlParameters.Companion.validateP
 import org.assertj.core.api.Assertions
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertTrue
 
@@ -153,6 +154,57 @@ class MaalingKtTest {
               ))
       val result = Maaling.toTestingFerdig(maaling)
       Assertions.assertThat(result).isNotNull
+    }
+  }
+
+  @DisplayName("findFerdigeTestKoeyringar")
+  @Nested
+  inner class FindFerdigeTestKoeyringar {
+    private val maaling =
+        Maaling.TestingFerdig(
+            1000,
+            "test",
+            listOf(
+                TestKoeyring.Ferdig(
+                    CrawlResultat.Ferdig(
+                        listOf(URL("https://www.uutilsynet.no")),
+                        URL("https://www.status.url"),
+                        TestConstants.uutilsynetLoeysing,
+                        Instant.now()),
+                    Instant.now(),
+                    URL("https://www.status.url"),
+                    emptyList(),
+                    AutoTesterClient.AutoTesterOutput.Lenker(
+                        URL("https://fullt.resultat"), URL("https://brot.resultat"))),
+                TestKoeyring.Ferdig(
+                    CrawlResultat.Ferdig(
+                        listOf(URL("https://www.digdir.no")),
+                        URL("https://www.status.url"),
+                        TestConstants.digdirLoeysing,
+                        Instant.now()),
+                    Instant.now(),
+                    URL("https://www.status.url"),
+                    emptyList(),
+                    AutoTesterClient.AutoTesterOutput.Lenker(
+                        URL("https://fullt.resultat"), URL("https://brot.resultat")))))
+
+    @DisplayName(
+        "når vi henter testkøyringar for ei måling, uten å spesifisere løysing, så skal vi få alle testkøyringane")
+    @Test
+    fun alleTestKoeyringar() {
+      val testKoeyringar = Maaling.findFerdigeTestKoeyringar(maaling)
+      assertThat(testKoeyringar, hasSize(2))
+    }
+
+    @DisplayName(
+        "når vi henter testkøyringar for ei måling, og spesifiserer ei løysing, så skal vi få testkøyringane for den løysinga")
+    @Test
+    fun testKoeyringarForLoeysing() {
+      val testKoeyringar =
+          Maaling.findFerdigeTestKoeyringar(maaling, TestConstants.uutilsynetLoeysing.id)
+      assertThat(testKoeyringar, hasSize(1))
+      assertThat(
+          testKoeyringar[0].crawlResultat.loeysing, equalTo(TestConstants.uutilsynetLoeysing))
     }
   }
 }


### PR DESCRIPTION
Henter testresultat for måling og løysing fra dataplattformen, i stedet for fra databasen.

DFK-216