### PR TITLE
tar med feilmelding fra crawler

### DIFF
--- a/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/CrawlResultat.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/maaling/CrawlResultat.kt
@@ -78,10 +78,7 @@ fun updateStatus(crawlResultat: CrawlResultat, newStatus: CrawlStatus): CrawlRes
                 )
               }
           is CrawlStatus.Failed ->
-              CrawlResultat.Feilet(
-                  "Crawling av ${crawlResultat.loeysing.url} feilet.",
-                  crawlResultat.loeysing,
-                  Instant.now())
+              CrawlResultat.Feilet(newStatus.output, crawlResultat.loeysing, Instant.now())
           is CrawlStatus.Terminated ->
               CrawlResultat.Feilet(
                   "Crawling av ${crawlResultat.loeysing.url} ble avbrutt.",


### PR DESCRIPTION
Fjerner den gamle feilmeldingen, fordi:
1. Vi vet at det har feilet, pga. statusen.
2. Vi vet hvilken løsning det er snakk om, fordi det er et felt på CrawlResultat.

Legger til feilmelding fra crawleren.