### PR TITLE
drop table loeysing

### DIFF
--- a/src/main/resources/db/migration/V37__drop-table-loeysing.sql
+++ b/src/main/resources/db/migration/V37__drop-table-loeysing.sql
@@ -1,0 +1,1 @@
+drop table loeysing;


### PR DESCRIPTION
Fjerner loeysing-tabellen fra databasen, siden dataene er flyttet til løsningsregisteret.