### PR TITLE
lagrer testregler sammen med en sak

### DIFF
--- a/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/Sak.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/Sak.kt
@@ -1,6 +1,12 @@
 package no.uutilsynet.testlab2testing.inngaendekontroll
 
-data class Sak(val virksomhet: String, val loeysingar: List<Loeysing> = emptyList()) {
+import no.uutilsynet.testlab2testing.testregel.Testregel
+
+data class Sak(
+    val virksomhet: String,
+    val loeysingar: List<Loeysing> = emptyList(),
+    val testreglar: List<Testregel> = emptyList()
+) {
   data class Loeysing(val loeysingId: Int, val nettsider: List<Nettside> = emptyList())
 
   data class Nettside(

--- a/src/main/kotlin/no/uutilsynet/testlab2testing/testregel/TestregelDAO.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/testregel/TestregelDAO.kt
@@ -86,4 +86,16 @@ class TestregelDAO(val jdbcTemplate: NamedParameterJdbcTemplate) {
   fun getTestreglarForMaaling(maalingId: Int): Result<List<Testregel>> = runCatching {
     jdbcTemplate.query(maalingTestregelSql, mapOf("id" to maalingId), testregelRowMapper)
   }
+
+  fun getTestreglarBySak(sakId: Int): List<Testregel> =
+      jdbcTemplate.query(
+          """
+          select t.id, t.name, t.krav, t.testregel_schema, t.type
+          from testregel t
+          join sak_testregel st on t.id = st.testregel_id
+          where st.sak_id = :sak_id
+      """
+              .trimIndent(),
+          mapOf("sak_id" to sakId),
+          DataClassRowMapper.newInstance(Testregel::class.java))
 }

--- a/src/main/resources/db/migration/V44__create-table-sak_testregel.sql
+++ b/src/main/resources/db/migration/V44__create-table-sak_testregel.sql
@@ -1,0 +1,5 @@
+create table sak_testregel
+(
+    sak_id       int references sak (id),
+    testregel_id int references testregel (id)
+)


### PR DESCRIPTION
Utvider modellen for sak for å kunne lagre testregler. På samme måte som for løsninger, legges saker til ved å sende inn det komplette objektet som en oppdatering.

DFK-375