### PR TITLE
hent alle resultater for en sak

### DIFF
--- a/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/testresultat/ResultatManuellKontroll.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/testresultat/ResultatManuellKontroll.kt
@@ -2,31 +2,17 @@ package no.uutilsynet.testlab2testing.inngaendekontroll.testresultat
 
 import java.time.Instant
 
-sealed class ResultatManuellKontroll {
-  data class UnderArbeid(
-      val id: Int,
-      val sakId: Int,
-      val loeysingId: Int,
-      val testregelId: Int,
-      val nettsideId: Int,
-      val elementOmtale: String?,
-      val elementResultat: String?,
-      val elementUtfall: String?,
-      val svar: List<Svar>
-  ) : ResultatManuellKontroll()
-
-  data class Ferdig(
-      val id: Int,
-      val sakId: Int,
-      val loeysingId: Int,
-      val testregelId: Int,
-      val nettsideId: Int,
-      val elementOmtale: String,
-      val elementResultat: String,
-      val elementUtfall: String,
-      val svar: List<Svar>,
-      val testVartUtfoert: Instant
-  ) : ResultatManuellKontroll()
-
+data class ResultatManuellKontroll(
+    val id: Int,
+    val sakId: Int,
+    val loeysingId: Int,
+    val testregelId: Int,
+    val nettsideId: Int,
+    val elementOmtale: String?,
+    val elementResultat: String?,
+    val elementUtfall: String?,
+    val svar: List<Svar>,
+    val testVartUtfoert: Instant?
+) {
   data class Svar(val steg: String, val svar: String)
 }

--- a/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/testresultat/TestResultatResource.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/testresultat/TestResultatResource.kt
@@ -22,7 +22,7 @@ class TestResultatResource(val testResultatDAO: TestResultatDAO) {
               { ResponseEntity.internalServerError().build() })
 
   @GetMapping("/{id}")
-  fun getTestResultat(@PathVariable id: Int): ResponseEntity<ResultatManuellKontroll> {
+  fun getOneResult(@PathVariable id: Int): ResponseEntity<ResultatManuellKontroll> {
     return testResultatDAO
         .getTestResultat(id)
         .fold(
@@ -33,10 +33,24 @@ class TestResultatResource(val testResultatDAO: TestResultatDAO) {
             })
   }
 
+  @GetMapping("")
+  fun getManyResults(
+      @RequestParam sakId: Int
+  ): ResponseEntity<Map<String, List<ResultatManuellKontroll>>> {
+    return testResultatDAO
+        .getManyResults(sakId)
+        .fold(
+            onSuccess = { ResponseEntity.ok(mapOf("resultat" to it)) },
+            onFailure = {
+              logger.error("Feil ved henting av testresultat", it)
+              ResponseEntity.internalServerError().build()
+            })
+  }
+
   @PutMapping("/{id}")
   fun updateTestResultat(
       @PathVariable id: Int,
-      @RequestBody testResultat: ResultatManuellKontroll.UnderArbeid
+      @RequestBody testResultat: ResultatManuellKontroll
   ): ResponseEntity<Unit> {
     require(testResultat.id == id) { "id i URL-en og id i dei innsendte dataene er ikkje den same" }
     return testResultatDAO


### PR DESCRIPTION
Nytt endepunkt for å hente alle resultater for en sak. Forenkler også modellen for ResultatManuellKontroll, siden vi ikke har behov for å skille mellom et resultat som er under arbeid, og et som er ferdig.

DFK-421
