### PR TITLE
endrer navn på tabell, og fjerner resultat fra testkoeyring

### DIFF
--- a/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/testresultat/TestResultatDAO.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/testresultat/TestResultatDAO.kt
@@ -13,7 +13,7 @@ class TestResultatDAO(val jdbcTemplate: NamedParameterJdbcTemplate) {
     return runCatching {
       jdbcTemplate.queryForObject(
           """
-        insert into testresultat_ik (sak_id, loeysing_id, testregel_id, nettside_id, element_omtale, element_resultat,
+        insert into testresultat (sak_id, loeysing_id, testregel_id, nettside_id, element_omtale, element_resultat,
                                      element_utfall, test_vart_utfoert)
         values (:sakId, :loeysingId, :testregelId, :nettsideId, :elementOmtale, :elementResultat, :elementUtfall,
                 :testVartUtfoert)
@@ -61,8 +61,8 @@ class TestResultatDAO(val jdbcTemplate: NamedParameterJdbcTemplate) {
                        ti.test_vart_utfoert,
                        tis.steg as svar_steg,
                        tis.svar as svar_svar
-                from testresultat_ik ti
-                         left join testresultat_ik_svar tis on ti.id = tis.testresultat_ik_id
+                from testresultat ti
+                         left join testresultat_svar tis on ti.id = tis.testresultat_ik_id
                 where ${if (resultatId != null) "ti.id = :id" else "true"}
                 and ${if (sakId != null) "ti.sak_id = :sakId" else "true"}
                 order by id, svar_steg
@@ -83,7 +83,7 @@ class TestResultatDAO(val jdbcTemplate: NamedParameterJdbcTemplate) {
         else null
     jdbcTemplate.update(
         """
-      update testresultat_ik
+      update testresultat
       set element_omtale    = :elementOmtale,
           element_resultat  = :elementResultat,
           element_utfall    = :elementUtfall,
@@ -101,7 +101,7 @@ class TestResultatDAO(val jdbcTemplate: NamedParameterJdbcTemplate) {
     // slett gamle svar og lagre de nye
     jdbcTemplate.update(
         """
-            delete from testresultat_ik_svar
+            delete from testresultat_svar
             where testresultat_ik_id = :id
         """
             .trimIndent(),
@@ -115,7 +115,7 @@ class TestResultatDAO(val jdbcTemplate: NamedParameterJdbcTemplate) {
 
         jdbcTemplate.update(
             """
-            insert into testresultat_ik_svar (testresultat_ik_id, steg, svar)
+            insert into testresultat_svar (testresultat_ik_id, steg, svar)
             values (:testresultatId, :steg, :svar)
             on conflict (testresultat_ik_id, steg) do update
             set svar = excluded.svar

--- a/src/main/resources/db/migration/V48__rename-table-testresultat_ik.sql
+++ b/src/main/resources/db/migration/V48__rename-table-testresultat_ik.sql
@@ -1,0 +1,5 @@
+drop table testresultat;
+alter table testresultat_ik
+    rename to testresultat;
+alter table testresultat_ik_svar
+    rename to testresultat_svar;

--- a/src/test/kotlin/no/uutilsynet/testlab2testing/forenkletkontroll/MaalingDAOTest.kt
+++ b/src/test/kotlin/no/uutilsynet/testlab2testing/forenkletkontroll/MaalingDAOTest.kt
@@ -133,50 +133,6 @@ class MaalingDAOTest(
   }
 
   @DisplayName(
-      "når vi lagrer ei måling med status `testing_ferdig` og testresultater, så skal alle resultatene også lagres")
-  @Test
-  fun lagreResultater() {
-    val maaling = createTestMaaling()
-    val crawlResultat =
-        maaling.loeysingList.map {
-          CrawlResultat.Ferdig(
-              1, URI("https://status.uri").toURL(), it, Instant.now(), it.url.toUrlListWithPages())
-        }
-    val kvalitetssikring = Maaling.toKvalitetssikring(Maaling.toCrawling(maaling, crawlResultat))!!
-    maalingDAO.save(kvalitetssikring)
-    val testKoeyringar =
-        crawlResultat.map {
-          TestKoeyring.Ferdig(
-              it,
-              Instant.now(),
-              URI("https://teststatus.url").toURL(),
-              listOf(
-                  TestResultat(
-                      listOf("3.1.1"),
-                      it.loeysing.url,
-                      "QW-ACT-R5",
-                      1,
-                      TestResultat.parseLocalDateTime("3/23/2023, 11:15:54 AM"),
-                      "The `lang` attribute has a valid value.",
-                      "samsvar",
-                      TestResultat.ACTElement(
-                          "html",
-                          "PGh0bWwgbGFuZz0ibm4iIGRpcj0ibHRyIiBwcmVmaXg9Im9nOiBodHRwczovL29ncC5tZS9ucyMiIGNsYXNzPSIganMiPjxoZWFkPjwvaGVhZD48Ym9keT53aW5kb3cuZGF0YQ=="))))
-        }
-    val testing = Maaling.toTesting(kvalitetssikring, testKoeyringar)
-    val testingFerdig = Maaling.toTestingFerdig(testing)!!
-    maalingDAO.save(testingFerdig).getOrThrow()
-    val id = maaling.id
-    val maalingFraDatabasen = maalingDAO.getMaaling(id) as Maaling.TestingFerdig
-    val testResultat =
-        maalingFraDatabasen.testKoeyringar
-            .filterIsInstance<TestKoeyring.Ferdig>()
-            .flatMap { it.testResultat }
-            .first()
-    assertThat(testResultat.testregelId).isEqualTo("QW-ACT-R5")
-  }
-
-  @DisplayName(
       "når vi lagrer ei måling med status `testing_ferdig` og med lenker til testresultatene, så skal lenkene også lagres")
   @Test
   fun lagreLenker() {
@@ -185,7 +141,6 @@ class MaalingDAOTest(
     val maalingFromDatabase = maalingDAO.getMaaling(id) as Maaling.TestingFerdig
 
     val testKoeyring = maalingFromDatabase.testKoeyringar[0] as TestKoeyring.Ferdig
-    assertThat(testKoeyring.testResultat).isEmpty()
     assertThat(testKoeyring.lenker?.urlFulltResultat)
         .isEqualTo(URI("https://fullt.resultat").toURL())
     assertThat(testKoeyring.lenker?.urlBrot).isEqualTo(URI("https://brot.resultat").toURL())
@@ -358,7 +313,6 @@ class MaalingDAOTest(
               it,
               Instant.now(),
               URI("https://teststatus.url").toURL(),
-              emptyList(),
               AutoTesterClient.AutoTesterOutput.Lenker(
                   URI("https://fullt.resultat").toURL(),
                   URI("https://brot.resultat").toURL(),

--- a/src/test/kotlin/no/uutilsynet/testlab2testing/forenkletkontroll/MaalingKtTest.kt
+++ b/src/test/kotlin/no/uutilsynet/testlab2testing/forenkletkontroll/MaalingKtTest.kt
@@ -95,10 +95,7 @@ class MaalingKtTest {
   inner class TestingFerdigTests {
     private val crawlResultatForUUTilsynet =
         CrawlResultat.Ferdig(
-            1,
-            URI("https://www.status.url").toURL(),
-            TestConstants.uutilsynetLoeysing,
-            Instant.now())
+            1, URI("https://www.status.url").toURL(), uutilsynetLoeysing, Instant.now())
     private val crawlResultatForDigdir =
         CrawlResultat.Ferdig(
             1, URI("https://www.status.url").toURL(), digdirLoeysing, Instant.now())
@@ -207,7 +204,7 @@ class MaalingKtTest {
                       crawlResultatForUUTilsynet,
                       Instant.now(),
                       URI("https://status.url").toURL(),
-                      TestKoeyringTest.testResultater())))
+                      lenker)))
       val result = Maaling.toTestingFerdig(maaling)
       assertThat(result).isNotNull
     }
@@ -227,7 +224,7 @@ class MaalingKtTest {
                       crawlResultatForUUTilsynet,
                       Instant.now(),
                       URI("https://status.url").toURL(),
-                      TestKoeyringTest.testResultater()),
+                      lenker),
               ))
       val result = Maaling.toTestingFerdig(maaling)
       assertThat(result).isNotNull
@@ -247,35 +244,17 @@ class MaalingKtTest {
                     CrawlResultat.Ferdig(
                         1,
                         URI("https://www.status.url").toURL(),
-                        TestConstants.uutilsynetLoeysing,
+                        uutilsynetLoeysing,
                         Instant.now()),
                     Instant.now(),
                     URI("https://www.status.url").toURL(),
-                    emptyList(),
-                    AutoTesterClient.AutoTesterOutput.Lenker(
-                        URI("https://fullt.resultat").toURL(),
-                        URI("https://brot.resultat").toURL(),
-                        URI("https://aggregeringTR.resultat").toURL(),
-                        URI("https://aggregeringSK.resultat").toURL(),
-                        URI("https://aggregeringSide.resultat").toURL(),
-                        URI("https://aggregeringSideTR.resultat").toURL(),
-                        URI("https://aggregeringLoeysing.resultat").toURL(),
-                    )),
+                    lenker),
                 TestKoeyring.Ferdig(
                     CrawlResultat.Ferdig(
                         1, URI("https://www.status.url").toURL(), digdirLoeysing, Instant.now()),
                     Instant.now(),
                     URI("https://www.status.url").toURL(),
-                    emptyList(),
-                    AutoTesterClient.AutoTesterOutput.Lenker(
-                        URI("https://fullt.resultat").toURL(),
-                        URI("https://brot.resultat").toURL(),
-                        URI("https://aggregeringTR.resultat").toURL(),
-                        URI("https://aggregeringSK.resultat").toURL(),
-                        URI("https://aggregering.resultatSide").toURL(),
-                        URI("https://aggregeringSideTR.resultat").toURL(),
-                        URI("https://aggregeringLoeysing.resultat").toURL(),
-                    ))))
+                    lenker)))
 
     @DisplayName(
         "når vi henter testkøyringar for ei måling, uten å spesifisere løysing, så skal vi få alle testkøyringane")
@@ -289,11 +268,20 @@ class MaalingKtTest {
         "når vi henter testkøyringar for ei måling, og spesifiserer ei løysing, så skal vi få testkøyringane for den løysinga")
     @Test
     fun testKoeyringarForLoeysing() {
-      val testKoeyringar =
-          Maaling.findFerdigeTestKoeyringar(maaling, TestConstants.uutilsynetLoeysing.id)
+      val testKoeyringar = Maaling.findFerdigeTestKoeyringar(maaling, uutilsynetLoeysing.id)
       assertThat(testKoeyringar, hasSize(1))
-      assertThat(
-          testKoeyringar[0].crawlResultat.loeysing, equalTo(TestConstants.uutilsynetLoeysing))
+      assertThat(testKoeyringar[0].crawlResultat.loeysing, equalTo(uutilsynetLoeysing))
     }
   }
 }
+
+val lenker =
+    AutoTesterClient.AutoTesterOutput.Lenker(
+        URI("https://fullt.resultat").toURL(),
+        URI("https://brot.resultat").toURL(),
+        URI("https://aggregeringTR.resultat").toURL(),
+        URI("https://aggregeringSK.resultat").toURL(),
+        URI("https://aggregeringSide.resultat").toURL(),
+        URI("https://aggregeringSideTR.resultat").toURL(),
+        URI("https://aggregeringLoeysing.resultat").toURL(),
+    )

--- a/src/test/kotlin/no/uutilsynet/testlab2testing/forenkletkontroll/TestConstants.kt
+++ b/src/test/kotlin/no/uutilsynet/testlab2testing/forenkletkontroll/TestConstants.kt
@@ -46,7 +46,6 @@ object TestConstants {
           crawlResultat,
           Instant.now(),
           URI("https://status.url").toURL(),
-          emptyList(),
           AutoTesterClient.AutoTesterOutput.Lenker(
               URI("https://fullt.resultat").toURL(),
               URI("https://brot.resultat").toURL(),
@@ -62,7 +61,6 @@ object TestConstants {
           crawlResultat2,
           Instant.now(),
           URI("https://status.url").toURL(),
-          emptyList(),
           AutoTesterClient.AutoTesterOutput.Lenker(
               URI("https://fullt.resultat").toURL(),
               URI("https://brot.resultat").toURL(),

--- a/src/test/kotlin/no/uutilsynet/testlab2testing/forenkletkontroll/TestKoeyringTest.kt
+++ b/src/test/kotlin/no/uutilsynet/testlab2testing/forenkletkontroll/TestKoeyringTest.kt
@@ -1,22 +1,16 @@
 package no.uutilsynet.testlab2testing.forenkletkontroll
 
-import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import java.net.URI
 import java.time.Instant
 import java.util.stream.Stream
 import no.uutilsynet.testlab2testing.forenkletkontroll.TestConstants.crawlResultat
 import no.uutilsynet.testlab2testing.forenkletkontroll.TestConstants.statusURL
-import no.uutilsynet.testlab2testing.forenkletkontroll.TestConstants.uutilsynetLoeysing
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.junit.jupiter.params.provider.ValueSource
 
 class TestKoeyringTest {
 
@@ -25,7 +19,7 @@ class TestKoeyringTest {
   fun nyTestKoeyring() {
     val actual = TestKoeyring.from(crawlResultat, URI(statusURL).toURL())
     assertThat(actual).isInstanceOf(TestKoeyring.IkkjeStarta::class.java)
-    assertThat((actual as TestKoeyring.IkkjeStarta).statusURL.toString()).isEqualTo(statusURL)
+    assertThat(actual.statusURL.toString()).isEqualTo(statusURL)
   }
 
   @ParameterizedTest
@@ -74,7 +68,7 @@ class TestKoeyringTest {
   @MethodSource("pairsOfResponseTilstand")
   fun testUpdateStatusFromFerdig(response: AutoTesterClient.AutoTesterStatus, tilstand: Class<*>) {
     val testKoeyring =
-        TestKoeyring.Ferdig(crawlResultat, Instant.now(), URI(statusURL).toURL(), testResultater())
+        TestKoeyring.Ferdig(crawlResultat, Instant.now(), URI(statusURL).toURL(), lenker = null)
     val actual = TestKoeyring.updateStatus(testKoeyring, response)
     assertThat(actual).isInstanceOf(TestKoeyring.Ferdig::class.java)
   }
@@ -87,354 +81,6 @@ class TestKoeyringTest {
     val testKoeyring = TestKoeyring.Feila(crawlResultat, Instant.now(), "dette går ikkje")
     val actual = TestKoeyring.updateStatus(testKoeyring, response)
     assertThat(actual).isInstanceOf(TestKoeyring.Feila::class.java)
-  }
-
-  @Nested
-  @DisplayName("aggregering på testregel")
-  inner class AggregeringPaaTestregel {
-    @DisplayName("gitt et testresultat for UUTilsynet")
-    @Nested
-    inner class TestResultatForUUTilsynet {
-      private val result = TestKoeyring.aggregerPaaTestregel(koeyringarMedResultat(), 46)
-
-      @Test
-      @DisplayName("så skal aggregeringen gi oss en liste med et element per testregel")
-      fun ettElementPerTestregel() {
-        assertThat(result.map { it.testregelId })
-            .containsExactly(
-                "QW-ACT-R1", "QW-ACT-R2", "QW-ACT-R5", "QW-ACT-R11", "QW-ACT-R28", "QW-ACT-R37")
-      }
-
-      @Test
-      @DisplayName("så skal hvert element i aggregeringen inneholde id-en på målingen")
-      fun maalingId() {
-        result.forEach { assertThat(it.maalingId).isEqualTo(46) }
-      }
-
-      @Test
-      @DisplayName("så skal hvert element i aggregeringen inneholde id-en på løsningen")
-      fun loeysingId() {
-        result.forEach { assertThat(it.loeysing.id).isEqualTo(1) }
-      }
-
-      @Test
-      @DisplayName("så skal hvert element i aggregeringen inneholde navnet på løsningen")
-      fun loeysingNavn() {
-        result.forEach { assertThat(it.loeysing.namn).isEqualTo("UUTilsynet") }
-      }
-
-      @ParameterizedTest
-      @ValueSource(
-          strings =
-              [
-                  "QW-ACT-R1 1",
-                  "QW-ACT-R2 1",
-                  "QW-ACT-R5 1",
-                  "QW-ACT-R11 2",
-                  "QW-ACT-R28 1",
-                  "QW-ACT-R37 0"])
-      @DisplayName("så skal antall tester med samsvar være gitt for hver aggregering")
-      fun antallTesterMedSamsvar(s: String) {
-        val (testregelId, antallSamsvar) = s.split(" ")
-        result
-            .find { it.testregelId == testregelId }
-            ?.let { assertThat(it.talElementSamsvar).isEqualTo(antallSamsvar.toInt()) }
-            ?: throw AssertionError("Fant ikke aggregering for testregel $testregelId")
-      }
-
-      @ParameterizedTest
-      @ValueSource(
-          strings =
-              [
-                  "QW-ACT-R1 0",
-                  "QW-ACT-R2 0",
-                  "QW-ACT-R5 0",
-                  "QW-ACT-R11 0",
-                  "QW-ACT-R28 1",
-                  "QW-ACT-R37 0"])
-      @DisplayName("så skal antall tester med brot være gitt for hver aggregering")
-      fun antallTesterMedBrot(s: String) {
-        val (testregelId, antallBrot) = s.split(" ")
-        result
-            .find { it.testregelId == testregelId }
-            ?.let { assertThat(it.talElementBrot).isEqualTo(antallBrot.toInt()) }
-            ?: throw AssertionError("Fant ikke aggregering for testregel $testregelId")
-      }
-
-      @ParameterizedTest
-      @ValueSource(
-          strings =
-              [
-                  "QW-ACT-R1 0",
-                  "QW-ACT-R2 0",
-                  "QW-ACT-R5 0",
-                  "QW-ACT-R11 0",
-                  "QW-ACT-R28 0",
-                  "QW-ACT-R37 2"])
-      @DisplayName("så skal antall tester med varsel være gitt for hver aggregering")
-      fun antallTesterMedVarsel(s: String) {
-        val (testregelId, antallVarsel) = s.split(" ")
-        result
-            .find { it.testregelId == testregelId }
-            ?.let { assertThat(it.talElementVarsel).isEqualTo(antallVarsel.toInt()) }
-            ?: throw AssertionError("Fant ikke aggregering for testregel $testregelId")
-      }
-
-      @ParameterizedTest
-      @ValueSource(
-          strings =
-              [
-                  "QW-ACT-R1 1",
-                  "QW-ACT-R2 1",
-                  "QW-ACT-R5 1",
-                  "QW-ACT-R11 2",
-                  "QW-ACT-R28 0",
-                  "QW-ACT-R37 0"])
-      @DisplayName("så skal antall sider med samsvar være gitt for hver aggregering")
-      fun antallSiderMedSamsvar(s: String) {
-        val (testregelId, antallSamsvar) = s.split(" ")
-        assertThat(result.find { it.testregelId == testregelId }?.talSiderSamsvar)
-            .isEqualTo(antallSamsvar.toInt())
-      }
-
-      @ParameterizedTest
-      @ValueSource(
-          strings =
-              [
-                  "QW-ACT-R1 0",
-                  "QW-ACT-R2 0",
-                  "QW-ACT-R5 0",
-                  "QW-ACT-R11 0",
-                  "QW-ACT-R28 1",
-                  "QW-ACT-R37 0"])
-      @DisplayName("så skal antall sider med samsvar være gitt for hver aggregering")
-      fun antallSiderMedBrot(s: String) {
-        val (testregelId, antallBrot) = s.split(" ")
-        assertThat(result.find { it.testregelId == testregelId }?.talSiderBrot)
-            .isEqualTo(antallBrot.toInt())
-      }
-
-      @ParameterizedTest
-      @ValueSource(
-          strings =
-              [
-                  "QW-ACT-R1 2",
-                  "QW-ACT-R2 2",
-                  "QW-ACT-R5 2",
-                  "QW-ACT-R11 1",
-                  "QW-ACT-R28 2",
-                  "QW-ACT-R37 2"])
-      @DisplayName("så skal antall sider uten forekomst være gitt for hver aggregering")
-      fun antallSiderUtenForekomst(s: String) {
-        val (testregelId, antallSiderUtenForekomst) = s.split(" ")
-        assertThat(result.find { it.testregelId == testregelId }?.talSiderIkkjeForekomst)
-            .isEqualTo(antallSiderUtenForekomst.toInt())
-      }
-
-      @Test
-      @DisplayName(
-          "så skal hver aggregering ha et felt for det første suksesskriteriet, og et felt for resten")
-      fun toFeltForSuksesskriterier() {
-        val testCases =
-            listOf(
-                Triple("QW-ACT-R1", "2.4.2", emptyList()),
-                Triple("QW-ACT-R2", "3.1.1", emptyList()),
-                Triple("QW-ACT-R5", "3.1.1", emptyList()),
-                Triple("QW-ACT-R11", "4.1.2", emptyList()),
-                Triple("QW-ACT-R28", "4.1.2", emptyList()),
-                Triple("QW-ACT-R37", "1.4.3", listOf("1.4.6")))
-
-        testCases.forEach { (testregelId, suksesskriterium, suksesskriterier) ->
-          val aggregeringR1 = result.find { it.testregelId == testregelId }
-          assertThat(aggregeringR1?.suksesskriterium).isEqualTo(suksesskriterium)
-          assertThat(aggregeringR1?.fleireSuksesskriterium).isEqualTo(suksesskriterier.toList())
-        }
-      }
-    }
-
-    private fun koeyringarMedResultat(): Map<TestKoeyring.Ferdig, List<TestResultat>> {
-      val testResultat =
-          jacksonObjectMapper()
-              .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-              .readValue(testResultatJson, object : TypeReference<List<TestResultat>>() {})
-      val nettsider = testResultat.map { it.side }.distinctBy { it.toString() }
-      val crawlResultat =
-          CrawlResultat.Ferdig(
-              nettsider.size, URI(statusURL).toURL(), uutilsynetLoeysing, Instant.now())
-      return mapOf(
-          TestKoeyring.Ferdig(crawlResultat, Instant.now(), URI(statusURL).toURL(), emptyList()) to
-              testResultat)
-    }
-
-    private val testResultatJson =
-        """
-      [
-        {
-          "suksesskriterium": [
-            "2.4.2"
-          ],
-          "side": "https://www.uutilsynet.no/side1",
-          "maalingId": 46,
-          "loeysingId": 1,
-          "testregelId": "QW-ACT-R1",
-          "sideNivaa": 1,
-          "testVartUtfoert": "3/23/2023, 11:15:54 AM",
-          "elementUtfall": "The `title` element exists and it's not empty ('').",
-          "elementResultat": "samsvar",
-          "elementOmtale": [
-            {
-              "pointer": "html > head:nth-child(1) > title:nth-child(18)",
-              "htmlCode": "PHRpdGxlPkRpZ2l0YWxlIGJhcnJpZXJhciB8IFRpbHN5bmV0IGZvciB1bml2ZXJzZWxsIHV0Zm9ybWluZyBhdiBpa3Q8L3RpdGxlPg=="
-            }
-          ]
-        },
-        {
-          "suksesskriterium": [
-            "3.1.1"
-          ],
-          "side": "https://www.uutilsynet.no/side1",
-          "maalingId": 46,
-          "loeysingId": 1,
-          "testregelId": "QW-ACT-R2",
-          "sideNivaa": 1,
-          "testVartUtfoert": "3/23/2023, 11:15:54 AM",
-          "elementUtfall": "The `lang` attribute exists and has a value.",
-          "elementResultat": "samsvar",
-          "elementOmtale": [
-            {
-              "pointer": "html",
-              "htmlCode": "PGh0bWwgbGFuZz0ibm4iIGRpcj0ibHRyIiBwcmVmaXg9Im9nOiBodHRwczovL29ncC5tZS9ucyMiIGNsYXNzPSIganMiPjxoZWFkPjwvaGVhZD48Ym9keT48L2JvZHk+PC9odA=="
-            }
-          ]
-        },
-        {
-          "suksesskriterium": [
-            "3.1.1"
-          ],
-          "side": "https://www.uutilsynet.no/side2",
-          "maalingId": 46,
-          "loeysingId": 1,
-          "testregelId": "QW-ACT-R5",
-          "sideNivaa": 1,
-          "testVartUtfoert": "3/23/2023, 11:15:54 AM",
-          "elementUtfall": "The `lang` attribute has a valid value.",
-          "elementResultat": "samsvar",
-          "elementOmtale": [
-            {
-              "pointer": "html",
-              "htmlCode": "PGh0bWwgbGFuZz0ibm4iIGRpcj0ibHRyIiBwcmVmaXg9Im9nOiBodHRwczovL29ncC5tZS9ucyMiIGNsYXNzPSIganMiPjxoZWFkPjwvaGVhZD48Ym9keT53aW5kb3cuZGF0YQ=="
-            }
-          ]
-        },
-        {
-          "suksesskriterium": [
-            "4.1.2"
-          ],
-          "side": "https://www.uutilsynet.no/side2",
-          "maalingId": 46,
-          "loeysingId": 1,
-          "testregelId": "QW-ACT-R11",
-          "sideNivaa": 1,
-          "testVartUtfoert": "3/23/2023, 11:15:54 AM",
-          "elementUtfall": "The test target has an accessible name.",
-          "elementResultat": "samsvar",
-          "elementOmtale": [
-            {
-              "pointer": "html > body:nth-child(2) > div:nth-child(2) > div:nth-child(1) > header:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > button:nth-child(1)",
-              "htmlCode": "PGJ1dHRvbiBjbGFzcz0iaGVhZGVyLWJ1dHRvbiBoZWFkZXItYnV0dG9uLS1zZWFyY2ggY29sbGFwc2VkIiBkYXRhLWJzLXRvZ2dsZT0iY29sbGFwc2UiIGRhdGEtYnMtdGFyZw=="
-            }
-          ]
-        },
-        {
-          "suksesskriterium": [
-            "4.1.2"
-          ],
-          "side": "https://www.uutilsynet.no/side3",
-          "maalingId": 46,
-          "loeysingId": 1,
-          "testregelId": "QW-ACT-R11",
-          "sideNivaa": 1,
-          "testVartUtfoert": "3/23/2023, 11:15:54 AM",
-          "elementUtfall": "The test target has an accessible name.",
-          "elementResultat": "samsvar",
-          "elementOmtale": [
-            {
-              "pointer": "html > body:nth-child(2) > div:nth-child(2) > div:nth-child(1) > header:nth-child(1) > div:nth-child(3) > div:nth-child(1) > nav:nth-child(1) > div:nth-child(1) > button:nth-child(1)",
-              "htmlCode": "PGJ1dHRvbiBpZD0ic3VibWVudS0tYnV0dG9uLS1pbnRyby10aWwtdXUiIGNsYXNzPSJzdWJtZW51X190b2dnbGUgdGV4dC1ib2R5LTMwMCBkcm9wZG93bi10b2dnbGUiIGRhdA=="
-            }
-          ]
-        },
-        {
-          "suksesskriterium": ["4.1.2"],
-          "side": "https://www.uutilsynet.no/side3",
-          "maalingId": 46,
-          "loeysingId": 1,
-          "testregelId": "QW-ACT-R28",
-          "sideNivaa": 0,
-          "testVartUtfoert": "4/19/2023, 11:37:55 AM",
-          "elementUtfall": "The test target `role` doesn't have required state or property",
-          "elementResultat": "samsvar",
-          "elementOmtale": [
-            {
-              "pointer": "html > body:nth-child(2) > div:nth-child(3) > div:nth-child(3) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(3) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(2) > div:nth-child(1)",
-              "htmlCode": "PGRpdiBpZD0iaW8tZmlsdGVyLXBhbmVsIiByb2xlPSJkaWFsb2ciIGFyaWEtbGFiZWxsZWRieT0iaW8tZmlsdGVyLXBhbmVsLWhlYWRpbmciIGNsYXNzPSJpby1maWx0ZXItcA=="
-            }
-          ]
-        },
-        {
-          "suksesskriterium": ["4.1.2"],
-          "side": "https://www.uutilsynet.no/side3",
-          "maalingId": 46,
-          "loeysingId": 1,
-          "testregelId": "QW-ACT-R28",
-          "sideNivaa": 0,
-          "testVartUtfoert": "4/19/2023, 11:37:55 AM",
-          "elementUtfall": "The test target has unlisted required states or properties.",
-          "elementResultat": "brot",
-          "elementOmtale": [
-            {
-              "pointer": "html > body:nth-child(2) > div:nth-child(3) > div:nth-child(3) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(3) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(2) > div:nth-child(1) > div:nth-child(2) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > label:nth-child(1) > input:nth-child(1)",
-              "htmlCode": "PGlucHV0IGFyaWEtZXhwYW5kZWQ9ImZhbHNlIiB0eXBlPSJzZWFyY2giIGF1dG9jb21wbGV0ZT0ib2ZmIiBwbGFjZWhvbGRlcj0iVmVpYWRyZXNzZSIgYXJpYS1oYXNwb3B1cA=="
-            }
-          ]
-        },
-        {
-          "suksesskriterium": ["1.4.3", "1.4.6"],
-          "side": "https://www.uutilsynet.no/side3",
-          "maalingId": 63,
-          "loeysingId": 4,
-          "testregelId": "QW-ACT-R37",
-          "sideNivaa": 0,
-          "testVartUtfoert": "4/21/2023, 8:17:26 AM",
-          "elementUtfall": "Element has an image on background.",
-          "elementResultat": "varsel",
-          "elementOmtale": [
-            {
-              "pointer": "html > body:nth-child(2) > main:nth-child(4) > section:nth-child(6) > div:nth-child(1) > div:nth-child(2) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(1) > a:nth-child(1) > div:nth-child(1)",
-              "htmlCode": "PGRpdiBjbGFzcz0iaW1hZ2UtdGl0bGUgd2hpdGUtdGl0bGUiPkJpdGNvaW4gVHV0b3JpYWw8L2Rpdj4="
-            }
-          ]
-        },
-        {
-          "suksesskriterium": ["1.4.3", "1.4.6"],
-          "side": "https://www.uutilsynet.no/side3",
-          "maalingId": 63,
-          "loeysingId": 4,
-          "testregelId": "QW-ACT-R37",
-          "sideNivaa": 0,
-          "testVartUtfoert": "4/21/2023, 8:17:26 AM",
-          "elementUtfall": "Element has an image on background.",
-          "elementResultat": "varsel",
-          "elementOmtale": [
-            {
-              "pointer": "html > body:nth-child(2) > main:nth-child(4) > section:nth-child(6) > div:nth-child(1) > div:nth-child(2) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1) > div:nth-child(1)",
-              "htmlCode": "PGRpdiBjbGFzcz0iaW1hZ2UtdGl0bGUgd2hpdGUtdGl0bGUiPkJsb2NrY2hhaW4gVHV0b3JpYWw8L2Rpdj4="
-            }
-          ]
-        }
-      ]
-    """
-            .trimIndent()
   }
 
   companion object {


### PR DESCRIPTION
Endrer navn på tabellen testresultat_ik til testresultat. Fjerner den gamle tabellen. Fjerner også testresultat fra TestKoeyring, siden det ikke brukes lenger.

DFK-426