### PR TITLE
endepunkt for å list ut alle saker

### DIFF
--- a/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/sak/Sak.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/sak/Sak.kt
@@ -1,5 +1,6 @@
 package no.uutilsynet.testlab2testing.inngaendekontroll.sak
 
+import java.time.Instant
 import no.uutilsynet.testlab2testing.testregel.Testregel
 
 data class Sak(
@@ -18,3 +19,6 @@ data class Sak(
       val begrunnelse: String
   )
 }
+
+/** Ein enklare versjon av Sak-klassen som brukast i lister. */
+data class SakListeElement(val id: Int, val virksomhet: String, val opprettet: Instant)

--- a/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/sak/SakDAO.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/sak/SakDAO.kt
@@ -147,4 +147,10 @@ class SakDAO(
     }
     sak
   }
+
+  fun getAlleSaker(): List<SakListeElement> {
+    return jdbcTemplate.query(
+        "select id, virksomhet, opprettet from sak",
+        DataClassRowMapper.newInstance(SakListeElement::class.java))
+  }
 }

--- a/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/sak/SakResource.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/sak/SakResource.kt
@@ -41,6 +41,11 @@ class SakResource(val sakDAO: SakDAO) {
             onFailure = { ResponseEntity.notFound().build() })
   }
 
+  @GetMapping
+  fun getAlleSaker(): ResponseEntity<List<SakListeElement>> {
+    return ResponseEntity.ok(sakDAO.getAlleSaker())
+  }
+
   @PutMapping("/{id}")
   fun updateSak(@PathVariable id: Int, @RequestBody sak: Sak): ResponseEntity<Sak> {
     require(sak.id == id) { "id i URL-en og id er ikkje den same" }

--- a/src/test/kotlin/no/uutilsynet/testlab2testing/TestTools.kt
+++ b/src/test/kotlin/no/uutilsynet/testlab2testing/TestTools.kt
@@ -1,0 +1,19 @@
+package no.uutilsynet.testlab2testing
+
+fun tilfeldigOrgnummer(): String {
+  val eightRandomDigits = (10000000..99999999).random()
+  val weights = listOf(3, 2, 7, 6, 5, 4, 3, 2)
+  val sum =
+      eightRandomDigits
+          .toString()
+          .map { it.toString().toInt() }
+          .zip(weights)
+          .sumOf { (a, b) -> a * b }
+  val checksum = 11 - (sum % 11)
+  if (checksum == 10) {
+    return tilfeldigOrgnummer()
+  } else {
+    val checksumDigit = if (checksum == 11) 0 else checksum
+    return eightRandomDigits.toString() + checksumDigit.toString()
+  }
+}


### PR DESCRIPTION
Nytt endepunkt for å liste ut alle saker. Elementene i lista inneholder bare id, virksomhet og opprettet tidspunkt. 

DFK-398
