### PR TITLE
endepunkt for å slette testresultat

### DIFF
--- a/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/testresultat/TestResultatDAO.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/testresultat/TestResultatDAO.kt
@@ -146,6 +146,16 @@ class TestResultatDAO(
             mapOf("testresultatId" to testresultatId, "steg" to steg, "svar" to svar))
       }
 
+  fun delete(id: Int): Result<Unit> = runCatching {
+    jdbcTemplate.update(
+        """
+            delete from testresultat
+            where id = :id
+        """
+            .trimIndent(),
+        mapOf("id" to id))
+  }
+
   fun saveAggregertResultatTestregel(sakId: Int) {
     val eksisterande = aggregeringDAO.getAggregertResultatTestregelForTestgrunnlag(sakId)
     if (eksisterande.isEmpty()) {

--- a/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/testresultat/TestResultatResource.kt
+++ b/src/main/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/testresultat/TestResultatResource.kt
@@ -75,6 +75,19 @@ class TestResultatResource(
   fun createAggregertResultat(@PathVariable testgrunnlagId: Int) =
       testResultatDAO.saveAggregertResultatTestregel(testgrunnlagId)
 
+  @DeleteMapping("/{id}")
+  fun deleteTestResultat(@PathVariable id: Int): ResponseEntity<Unit> {
+    logger.info("Sletter testresultat med id $id")
+    return testResultatDAO
+        .delete(id)
+        .fold(
+            onSuccess = { ResponseEntity.ok().build() },
+            onFailure = {
+              logger.error("Feil ved sletting av testresultat", it)
+              ResponseEntity.internalServerError().build()
+            })
+  }
+
   @GetMapping("/aggregert/{testgrunnlagId}")
   fun getAggregertResultat(@PathVariable testgrunnlagId: Int) =
       aggregeringService.getAggregertResultatTestregelForTestgrunnlag(testgrunnlagId)

--- a/src/test/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/testresultat/TestResultatResourceTest.kt
+++ b/src/test/kotlin/no/uutilsynet/testlab2testing/inngaendekontroll/testresultat/TestResultatResourceTest.kt
@@ -9,13 +9,8 @@ import no.uutilsynet.testlab2testing.inngaendekontroll.sak.Sak
 import no.uutilsynet.testlab2testing.inngaendekontroll.sak.SakDAO
 import no.uutilsynet.testlab2testing.inngaendekontroll.testresultat.ResultatManuellKontroll.Svar
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.*
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
-import org.junit.jupiter.api.Order
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.TestMethodOrder
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
@@ -189,6 +184,16 @@ class TestResultatResourceTest(
     val expected =
         (svar + restenAvSvarene).map { if (it.steg == "3.4") it.copy(svar = "nei") else it }
     assertThat(resultat.svar).containsExactlyElementsOf(expected)
+  }
+
+  @Test
+  @Order(9)
+  @DisplayName("vi skal kunne slette et testresultat")
+  fun sletteTestresultat() {
+    restTemplate.delete(location)
+    val resultatForSak =
+        restTemplate.getForObject("/testresultat?sakId=$sakId", ResultatForSak::class.java)!!
+    assertThat(resultatForSak.resultat).isEmpty()
   }
 
   data class ResultatForSak(val resultat: List<ResultatManuellKontroll>)


### PR DESCRIPTION
Legger til et endepunkt for å slette et gitt testresultat. Vi trenger dette for å kunne slette testresultater for et testelement på en testregel.

DFK-495